### PR TITLE
Fixed Dot Stack / Slider Logic and Massive Bomb Reset Improvements

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44402242, g: 0.49316543, b: 0.5722324, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 961251899}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -149,6 +151,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1571056490}
   m_RootOrder: 0
@@ -173,6 +176,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.47223732, b: 0, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -257,6 +261,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &319992546
 Canvas:
   m_ObjectHideFlags: 0
@@ -275,6 +280,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -288,6 +294,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1456938408}
   - {fileID: 1571056490}
@@ -327,6 +334,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1456938408}
   m_RootOrder: 1
@@ -351,6 +359,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.559549, g: 0.3584906, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -439,6 +448,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -499,6 +509,7 @@ MonoBehaviour:
       _noteJumpStartBeatOffset: 0
       bpm: 0
       mapName: 
+      songFilename: 
     BeatData:
       version: 
       colorNotes: []
@@ -533,9 +544,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 028a8d0594ba28441ad266b4c6fc580b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _customLevelPath: Path to the custom map goes here
-  _desiredDifficulty: 1
-  _previewMap: 0
+  _customLevelPath: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Beat Saber\\Beat
+    Saber_Data\\CustomLevels\\2a2ef (M\xF6bius - Timbo, abcbadq, Narwhal)"
+  _desiredDifficulty: 9
+  _previewMap: 1
   _beatSaberMapIDCSV: 
   _timeScale: 1
 --- !u!4 &453708160
@@ -548,6 +560,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.0014687, y: 1.138051, z: -12.629416}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -736,6 +749,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &705507995
@@ -748,10 +762,74 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!850595691 &961251899
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Settings.lighting
+  serializedVersion: 5
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 1
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 1
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 3
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 512
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 2
+  m_PVREnvironmentImportanceSampling: 0
+  m_PVRFilteringMode: 2
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
+  m_NumRaysToShootPerTexel: -1
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -831,6 +909,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.5, z: -40}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -862,6 +941,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1548289286}
   - {fileID: 425144534}
@@ -898,6 +978,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1548289285
 GameObject:
   m_ObjectHideFlags: 0
@@ -926,6 +1007,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1456938408}
   m_RootOrder: 0
@@ -950,6 +1032,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1003,6 +1086,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 74163853}
   - {fileID: 1674964574}
@@ -1039,6 +1123,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1674964573
 GameObject:
   m_ObjectHideFlags: 0
@@ -1067,6 +1152,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1571056490}
   m_RootOrder: 1
@@ -1091,6 +1177,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.2790139, g: 0.549661, b: 0.8962264, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -544,10 +544,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 028a8d0594ba28441ad266b4c6fc580b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _customLevelPath: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Beat Saber\\Beat
-    Saber_Data\\CustomLevels\\2a2ef (M\xF6bius - Timbo, abcbadq, Narwhal)"
+  _customLevelPath: Enter a map filepath here
   _desiredDifficulty: 9
-  _previewMap: 1
+  _previewMap: 0
   _beatSaberMapIDCSV: 
   _timeScale: 1
 --- !u!4 &453708160

--- a/Assets/Scripts/Core/LevelAudioLoader.cs
+++ b/Assets/Scripts/Core/LevelAudioLoader.cs
@@ -19,7 +19,7 @@ public class LevelAudioLoader : MonoBehaviour
         {
             yield return www.SendWebRequest();
 
-            if (www.isNetworkError || www.isHttpError)
+            if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
             {
                 Debug.LogError(www.error);
             }

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public interface IParityMethod {
@@ -10,6 +12,19 @@ public class DefaultParityCheck : IParityMethod
 {
     public bool UpsideDown { get { return _upsideDown; } }
     private bool _upsideDown;
+
+    private Dictionary<int, Func<ColourNote, int, int, bool>> _bombDetectionConditions = new()
+    {
+        { 0, (note,x,y) => ((y >= note.y && y == 2) || (y < note.y && y != 0)) && x == note.x },
+        { 1, (note,x,y) => ((y <= note.y && y == 0) || (y < note.y && y != 2)) && x == note.x },
+        { 2, (note,x,y) => y == note.y && x <= note.x  },
+        { 3, (note,x,y) => y == note.y && y >= note.x },
+        { 4, (note,x,y) => (y > note.y && x <= note.x) || (y >= note.y && x < note.x) || (y == note.y && x == note.x) },
+        { 5, (note,x,y) => (y > note.y && x >= note.x) || (y >= note.y && x > note.x) || (y == note.y && x == note.x) },
+        { 6, (note,x,y) => (y < note.y && x <= note.x) || (y <= note.y && x < note.x) || (y == note.y && x == note.x) },
+        { 7, (note,x,y) => (y < note.y && x >= note.x) || (y <= note.y && x > note.x) || (y == note.y && x == note.x) },
+        { 8, (note,x,y) => false }
+    };
 
     public Parity ParityCheck(BeatCutData lastCut, ref BeatCutData currentSwing, List<BombNote> bombs, float playerXOffset, bool rightHand)
     {
@@ -34,41 +49,58 @@ public class DefaultParityCheck : IParityMethod
 
         #region Bomb Reset Checks
 
-        // Checks if either bomb reset bomb locations exist
-        var bombCheckLayer = (lastCut.sliceParity == Parity.Forehand) ? 0 : 2;
-        bool containsRightmost = bombs.FindIndex(x => x.x == 2 + playerXOffset && x.y == bombCheckLayer 
-        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) > 0.15 && Mathf.Abs(x.b - nextNote.b) > 0.15) != -1;
-        bool containsLeftmost = bombs.FindIndex(x => x.x == 1 + playerXOffset && x.y == bombCheckLayer 
-        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) > 0.15 && Mathf.Abs(x.b - nextNote.b) > 0.15) != -1;
-
-        // If there is a bomb, potentially a bomb reset
-        if ((!rightHand && containsLeftmost) || (rightHand && containsRightmost))
+        // If last swing was entirely dots
+        if(lastCut.notesInCut.Count(x => x.d == 8) == lastCut.notesInCut.Count)
         {
-            // First check 
-            List<int> resetDirectionList = (lastCut.sliceParity == Parity.Forehand) ? SliceMap.forehandResetDict : SliceMap.backhandResetDict;
-            if (resetDirectionList.Contains(lastCut.notesInCut[0].d))
+            // Checks if either bomb reset bomb locations exist
+            var bombCheckLayer = (lastCut.sliceParity == Parity.Forehand) ? 0 : 2;
+            bool containsRightmost = bombs.FindIndex(x => x.x == 2 + playerXOffset && x.y == bombCheckLayer) != -1;
+            bool containsLeftmost = bombs.FindIndex(x => x.x == 1 + playerXOffset && x.y == bombCheckLayer) != -1;
+
+            // If there is a bomb, potentially a bomb reset
+            if ((!rightHand && containsLeftmost) || (rightHand && containsRightmost))
             {
-                currentSwing.resetType = ResetType.Bomb;
-                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
+                // Set the angle tolerance
+                float angleTolerance = 90;
+                if (lastCut.sliceParity == Parity.Backhand) { angleTolerance = 45; }
+
+                // If the swing falls under the angle tolerance, we predict its a bomb reset
+                // This catches bomb reset detection involving dot notes.
+                if (Mathf.Abs(lastCut.endPositioning.angle) <= angleTolerance)
+                {
+                    if ((lastCut.sliceParity == Parity.Forehand && nextNote.y > 0 && nextNote.d == 8)
+                        || (lastCut.sliceParity == Parity.Backhand && nextNote.y < 2 && nextNote.d == 8))
+                    {
+                        // If a dot note thats above or below the interactive bombs, and its dots, just swing
+                        // around the bombs
+                        return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
+                    }
+                    else
+                    {
+                        currentSwing.resetType = ResetType.Bomb;
+                        return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
+                    }
+                }
+            }
+        } else
+        {
+            // Structured so that successive bombs (for example, in a spiral) can be accounted for to some degree.
+            // Alternates the orientation each time so if bombs appear in the opposite spots, it flips
+            bool bombForcedReset = false;
+            for (int i = 0; i < bombs.Count; i++)
+            {
+                // Get bomb and next notes orientation
+                BombNote bomb = bombs[i];
+                ColourNote note = lastCut.notesInCut.Last(x => x.d != 8);
+                int orientation = note.d;
+                Vector2 assumedHandCoords = new Vector2(note.x, note.y);
+                bombForcedReset = _bombDetectionConditions[orientation](note, bomb.x, bomb.y);
+                if (bombForcedReset) break;
             }
 
-            // Set the angle tolerance
-            float angleTolerance = 90;
-
-            // If the swing falls under the angle tolerance, we predict its a bomb reset
-            // This catches bomb reset detection involving dot notes.
-            if (Mathf.Abs(lastCut.endPositioning.angle) <= angleTolerance)
-            {
-                if ((lastCut.sliceParity == Parity.Forehand && nextNote.y > 0 && nextNote.d == 8)
-                    || (lastCut.sliceParity == Parity.Backhand && nextNote.y < 2 && nextNote.d == 8))
-                {
-                    // If a dot note thats above or below the interactive bombs, and its dots, just swing
-                    // around the bombs
-                    return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
-                } else {
-                    currentSwing.resetType = ResetType.Bomb;
-                    return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
-                }
+            if(bombForcedReset && ((currentAFN! <= 0 && !rightHand) || (currentAFN !>= 0 && rightHand))) {
+                currentSwing.resetType = ResetType.Bomb;
+                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
             }
         }
 

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -22,10 +22,10 @@ public class DefaultParityCheck : IParityMethod
             (parity == Parity.Backhand && y == note.y && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) },
         { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) ||
             (parity == Parity.Backhand && y == note.y && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) },
-        { 4, (note, x, y, parity) => y == note.y && x == note.x && y != 0 },
-        { 5, (note, x, y, parity) => y == note.y && x == note.x && y != 0 },
-        { 6, (note, x, y, parity) => x == note.x && y == note.y && y != 2 },
-        { 7, (note, x, y, parity) => x == note.x && y == note.y && y != 2 },
+        { 4, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 5, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 6, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 7, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
         { 8, (note,x,y, parity) => false }
     };
 

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -37,20 +37,20 @@ public class DefaultParityCheck : IParityMethod
         // Checks if either bomb reset bomb locations exist
         var bombCheckLayer = (lastCut.sliceParity == Parity.Forehand) ? 0 : 2;
         bool containsRightmost = bombs.FindIndex(x => x.x == 2 + playerXOffset && x.y == bombCheckLayer 
-        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) !<= 0.15 && Mathf.Abs(x.b - nextNote.b) !<= 0.15) != -1;
+        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) > 0.15 && Mathf.Abs(x.b - nextNote.b) > 0.15) != -1;
         bool containsLeftmost = bombs.FindIndex(x => x.x == 1 + playerXOffset && x.y == bombCheckLayer 
-        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) !<= 0.15 && Mathf.Abs(x.b - nextNote.b)! <= 0.15) != -1;
+        && Mathf.Abs(x.b - lastCut.notesInCut[^1].b) > 0.15 && Mathf.Abs(x.b - nextNote.b) > 0.15) != -1;
 
         // If there is a bomb, potentially a bomb reset
         if ((!rightHand && containsLeftmost) || (rightHand && containsRightmost))
         {
             // First check 
-            /*List<int> resetDirectionList = (lastCut.sliceParity == Parity.Forehand) ? SliceMap.forehandResetDict : SliceMap.backhandResetDict;
+            List<int> resetDirectionList = (lastCut.sliceParity == Parity.Forehand) ? SliceMap.forehandResetDict : SliceMap.backhandResetDict;
             if (resetDirectionList.Contains(lastCut.notesInCut[0].d))
             {
                 currentSwing.resetType = ResetType.Bomb;
                 return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
-            }*/
+            }
 
             // Set the angle tolerance
             float angleTolerance = 90;
@@ -64,10 +64,6 @@ public class DefaultParityCheck : IParityMethod
                 {
                     // If a dot note thats above or below the interactive bombs, and its dots, just swing
                     // around the bombs
-                    return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
-                } else if ((lastCut.sliceParity == Parity.Forehand && nextNote.y > 0 && SliceMap.BackhandDict[nextNote.d] > 45)
-                   || (lastCut.sliceParity == Parity.Backhand && nextNote.y < 2 && SliceMap.ForehandDict[nextNote.d] > 45)) {
-                    // Not a reset, can be swung with parity based on note orientation?
                     return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
                 } else {
                     currentSwing.resetType = ResetType.Bomb;

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -113,16 +113,16 @@ public class DefaultParityCheck : IParityMethod
             return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
         }
 
-        // Alters big rotation swings to fall under the triangle condition below.
-        // Can cause some extreme prolonged no triangling if it trips up,
-        // need a better methodology to determine if reset by not a bomb
-        //if (currentAFN > 0) {
-        //    if (angleChange > 180 && !UpsideDown)
-       //     { angleChange -= 180; }
-        //}  else if (currentAFN < 0) {
-        //    if (angleChange < -180 && !UpsideDown)
-        //    { angleChange += 180; }
-        //}
+        // AKA, If a 180 anticlockwise (right) clockwise (left) rotation
+        if (lastCut.endPositioning.angle == 180) {
+            var altNextAFN = 180 + nextAFN;
+            if(altNextAFN >= 0) {
+                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
+            } else {
+                currentSwing.resetType = ResetType.Normal;
+                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
+            }
+        }
 
         // If the angle change exceeds 180 even after accounting for bigger rotations then triangle
         if (Mathf.Abs(angleChange) > 180 && !UpsideDown)

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -20,10 +20,10 @@ public class DefaultParityCheck : IParityMethod
         { 1, (note, x, y) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
         { 2, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x <= note.x },
         { 3, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x >= note.x },
-        { 4, (note, x, y) => y == note.y && x == note.x },
-        { 5, (note, x, y) => y == note.y && x == note.x },
-        { 6, (note, x, y) => x == note.x && y == note.y },
-        { 7, (note, x, y) => x == note.x && y <= note.y },
+        { 4, (note, x, y) => y == note.y && x == note.x && y != 0 },
+        { 5, (note, x, y) => y == note.y && x == note.x && y != 0 },
+        { 6, (note, x, y) => x == note.x && y == note.y && y != 2 },
+        { 7, (note, x, y) => x == note.x && y == note.y && y != 2 },
         { 8, (note,x,y) => false }
     };
 
@@ -42,38 +42,21 @@ public class DefaultParityCheck : IParityMethod
 
             // Get the last note. In the case of a stack, picks the note that isnt at 2 or 0 as
             // it triggers a reset when it shouldn't.
-            note = lastCut.notesInCut[^1];
-            if (lastCut.notesInCut.Count > 1)
-            {
-                if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Forehand)
-                {
-                    note = lastCut.notesInCut.FirstOrDefault(x => x.y != 0);
-                }
-                else if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Backhand)
-                {
-                    note = lastCut.notesInCut.FirstOrDefault(x => x.y != 2);
-                }
-            }
+            note = lastCut.notesInCut.Where(note => note.x == lastCut.endPositioning.x && note.y == lastCut.endPositioning.y).FirstOrDefault();
 
             // Get the last notes cut direction based on the last swings angle
             var lastNoteCutDir = (lastCut.sliceParity == Parity.Forehand) ?
                 SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
                 SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
 
-            // Offset the checking if the entire outerlane is full of bombs
+            // Offset the checking if the entire outerlane bombs indicate moving inwards
             int xOffset = 0;
-            if (note.x == 0)
-            {
-                bool a = bombs.Where(x => x.x == 0)
-                    .Where(x => x.y == 1 || x.y == 2 || x.y == 3).Any();
-                if (a) xOffset = 1;
-            }
-            else if (note.y == 1)
-            {
-                bool a = bombs.Where(x => x.x == 3)
-                    .Where(x => x.y == 1 || x.y == 2 || x.y == 3).Any();
-                if (a) xOffset = -1;
-            }
+
+            bool bombOffsetting = bombs.Any(bomb => bomb.x == note.x && (bomb.y <= note.y && lastCut.sliceParity == Parity.Backhand && lastCut.endPositioning.angle >= 0)) ||
+                bombs.Any(bomb => bomb.x == note.x && (bomb.y >= note.y && lastCut.sliceParity == Parity.Forehand && lastCut.endPositioning.angle >= 0));
+
+            if (bombOffsetting && note.x == 0) xOffset = 1;
+            if (bombOffsetting && note.x == 3) xOffset = -1;
 
             // Determine if lastnote and current bomb cause issue
             // If we already found reason to reset, no need to try again
@@ -102,7 +85,7 @@ public class DefaultParityCheck : IParityMethod
                 SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
                 SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
 
-        float nextAFN = (lastCut.sliceParity != Parity.Forehand) ?
+        float nextAFN = (lastCut.sliceParity == Parity.Forehand) ?
             SliceMap.BackhandDict[orient] :
             SliceMap.ForehandDict[orient];
 
@@ -117,27 +100,14 @@ public class DefaultParityCheck : IParityMethod
             _upsideDown = true;
         }
 
-        // Alters big rotation swings to fall under the triangle condition below.
-        // This works in the anticlockwise direction. Somehow, triangling still works.
-        if (currentAFN > 0) {
-            if (angleChange > 180 && !UpsideDown)
-            { angleChange -= 180; }
-        } else if (currentAFN < 0) {
-            if (angleChange < -180 && !UpsideDown)
-            { angleChange += 180; }
-        }
-
         // Check for potential bomb resets
         bool bombReset = BombResetCheck(lastCut, bombs);
 
         if (bombReset)
         {
-            if(Mathf.Abs(angleChange) < 180)
-            {
-                // Set as bomb reset and return same parity as last swing
-                currentSwing.resetType = ResetType.Bomb;
-                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
-            }
+            // Set as bomb reset and return same parity as last swing
+            currentSwing.resetType = ResetType.Bomb;
+            return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
         }
 
         // If the angle change exceeds 180 even after accounting for bigger rotations then triangle

--- a/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
@@ -57,7 +57,7 @@ public class ResetParityCheck : IParityMethod
 
             // Determine if lastnote and current bomb cause issue
             // If we already found reason to reset, no need to try again
-            bombReset = _bombDetectionConditions[lastNoteCutDir](new Vector2(note.x + xOffset, note.y), bomb.x, bomb.y);
+            bombReset = _bombDetectionConditions[lastNoteCutDir](new Vector2(note.x + xOffset, note.y), bomb.x, bomb.y, lastCut.sliceParity);
             if (bombReset) return true;
         }
         return false;

--- a/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
@@ -8,18 +8,58 @@ public class ResetParityCheck : IParityMethod
     public bool UpsideDown { get { return _upsideDown; } }
     private bool _upsideDown;
 
-    private Dictionary<int, Func<ColourNote, int, int, bool>> _bombDetectionConditions = new()
+    // Returns true if the inputted note and bomb coordinates cause a reset potentially
+    private Dictionary<int, Func<Vector2, int, int, bool>> _bombDetectionConditions = new()
     {
-        { 0, (note, x, y) => ((y >= note.y && y == 2) || (y < note.y && y != 0)) && x == note.x },
-        { 1, (note, x, y) => ((y <= note.y && y == 0) || (y < note.y && y != 2)) && x == note.x },
-        { 2, (note, x, y) => y == note.y && x <= note.x },
-        { 3, (note, x, y) => y == note.y && y >= note.x },
-        { 4, (note, x, y) => (y > note.y && x <= note.x) || (y >= note.y && x < note.x) || (y == note.y && x == note.x) },
-        { 5, (note, x, y) => (y > note.y && x >= note.x) || (y >= note.y && x > note.x) || (y == note.y && x == note.x) },
-        { 6, (note, x, y) => (y < note.y && x <= note.x) || (y <= note.y && x < note.x) || (y == note.y && x == note.x) },
-        { 7, (note, x, y) => (y < note.y && x >= note.x) || (y <= note.y && x > note.x) || (y == note.y && x == note.x) },
+        { 0, (note, x, y) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 1, (note, x, y) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 2, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x <= note.x },
+        { 3, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x >= note.x },
+        { 4, (note, x, y) => y == note.y && x == note.x && y != 0 },
+        { 5, (note, x, y) => y == note.y && x == note.x && y != 0 },
+        { 6, (note, x, y) => x == note.x && y == note.y && y != 2 },
+        { 7, (note, x, y) => x == note.x && y == note.y && y != 2 },
         { 8, (note, x, y) => false }
     };
+
+    public bool BombResetCheck(BeatCutData lastCut, List<BombNote> bombs)
+    {
+        // Not found yet
+        bool bombReset = false;
+        for (int i = 0; i < bombs.Count; i++)
+        {
+            // Get current bomb
+            BombNote bomb = bombs[i];
+            ColourNote note;
+
+            // If in the center 2 grid spaces, no point trying
+            if ((bomb.x == 1 || bomb.x == 2) && bomb.y == 1) continue;
+
+            // Get the last note. In the case of a stack, picks the note that isnt at 2 or 0 as
+            // it triggers a reset when it shouldn't.
+            note = lastCut.notesInCut.Where(note => note.x == lastCut.endPositioning.x && note.y == lastCut.endPositioning.y).FirstOrDefault();
+
+            // Get the last notes cut direction based on the last swings angle
+            var lastNoteCutDir = (lastCut.sliceParity == Parity.Forehand) ?
+                SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
+                SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
+
+            // Offset the checking if the entire outerlane bombs indicate moving inwards
+            int xOffset = 0;
+
+            bool bombOffsetting = bombs.Any(bomb => bomb.x == note.x && (bomb.y <= note.y && lastCut.sliceParity == Parity.Backhand && lastCut.endPositioning.angle >= 0)) ||
+                bombs.Any(bomb => bomb.x == note.x && (bomb.y >= note.y && lastCut.sliceParity == Parity.Forehand && lastCut.endPositioning.angle >= 0));
+
+            if (bombOffsetting && note.x == 0) xOffset = 1;
+            if (bombOffsetting && note.x == 3) xOffset = -1;
+
+            // Determine if lastnote and current bomb cause issue
+            // If we already found reason to reset, no need to try again
+            bombReset = _bombDetectionConditions[lastNoteCutDir](new Vector2(note.x + xOffset, note.y), bomb.x, bomb.y);
+            if (bombReset) return true;
+        }
+        return false;
+    }
 
     public Parity ParityCheck(BeatCutData lastCut, ref BeatCutData currentSwing, List<BombNote> bombs, float playerXOffset, bool rightHand)
     {
@@ -31,64 +71,31 @@ public class ResetParityCheck : IParityMethod
 
         ColourNote nextNote = currentSwing.notesInCut[0];
 
-        float angleChange = 0;
         float currentAFN = (lastCut.sliceParity != Parity.Forehand) ?
             SliceMap.BackhandDict[lastCut.notesInCut[0].d] :
             SliceMap.ForehandDict[lastCut.notesInCut[0].d];
-        float nextAFN = (lastCut.sliceParity != Parity.Forehand) ?
-            SliceMap.BackhandDict[nextNote.d] :
-            SliceMap.ForehandDict[nextNote.d];
 
-        angleChange = currentAFN - nextAFN;
+        int orient = nextNote.d;
+        if (nextNote.d == 8) orient = (lastCut.sliceParity == Parity.Forehand) ?
+                 SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
+                 SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
 
-        #region Bomb Reset Checks
+        float nextAFN = (lastCut.sliceParity == Parity.Forehand) ?
+            SliceMap.BackhandDict[orient] :
+            SliceMap.ForehandDict[orient];
 
-        // Structured so that successive bombs (for example, in a spiral) can be accounted for to some degree.
-        // Alternates the orientation each time so if bombs appear in the opposite spots, it flips
-        bool bombReset = false;
-        for (int i = 0; i < bombs.Count; i++)
-        {
-            // Get current bomb
-            BombNote bomb = bombs[i];
-            ColourNote note;
+        float angleChange = currentAFN - nextAFN;
+        _upsideDown = false;
 
-            // Get the last note. In the case of a stack, picks the note that isnt at 2 or 0 as
-            // it triggers a reset when it shouldn't.
-            note = lastCut.notesInCut[^1];
-            if (lastCut.notesInCut.Count > 1)
-            {
-                if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Forehand)
-                {
-                    note = lastCut.notesInCut.First(x => x.y != 0);
-                }
-                else if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Backhand)
-                {
-                    note = lastCut.notesInCut.First(x => x.y != 2);
-                }
-            }
-
-            // Get the last notes cut direction based on the last swings angle
-            var lastNoteCutDir = (lastCut.sliceParity == Parity.Forehand) ?
-                SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
-                SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
-
-            // Use the dictionary to determine if a reset should be called given bomb position and note position
-            bombReset = _bombDetectionConditions[lastNoteCutDir](note, bomb.x, bomb.y);
-            if (bombReset) break;
-        }
+        // Check for potential bomb resets
+        bool bombReset = BombResetCheck(lastCut, bombs);
 
         if (bombReset)
         {
-            // TEMP: This IF statement seemed to help catch dot spirals for now, but probably causes issues somewhere
-            if ((rightHand && nextAFN > -180) || (!rightHand && nextAFN < 180))
-            {
-                // Set as bomb reset and return same parity as last swing
-                currentSwing.resetType = ResetType.Bomb;
-                return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
-            }
+            // Set as bomb reset and return same parity as last swing
+            currentSwing.resetType = ResetType.Bomb;
+            return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
         }
-
-        #endregion
 
         // If note is a dot, play it as a down hit
         if (nextNote.d == 8 && nextNote.y == 0) { return Parity.Forehand; }

--- a/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
@@ -1,10 +1,25 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class ResetParityCheck : IParityMethod
 {
     public bool UpsideDown { get { return _upsideDown; } }
     private bool _upsideDown;
+
+    private Dictionary<int, Func<ColourNote, int, int, bool>> _bombDetectionConditions = new()
+    {
+        { 0, (note, x, y) => ((y >= note.y && y == 2) || (y < note.y && y != 0)) && x == note.x },
+        { 1, (note, x, y) => ((y <= note.y && y == 0) || (y < note.y && y != 2)) && x == note.x },
+        { 2, (note, x, y) => y == note.y && x <= note.x },
+        { 3, (note, x, y) => y == note.y && y >= note.x },
+        { 4, (note, x, y) => (y > note.y && x <= note.x) || (y >= note.y && x < note.x) || (y == note.y && x == note.x) },
+        { 5, (note, x, y) => (y > note.y && x >= note.x) || (y >= note.y && x > note.x) || (y == note.y && x == note.x) },
+        { 6, (note, x, y) => (y < note.y && x <= note.x) || (y <= note.y && x < note.x) || (y == note.y && x == note.x) },
+        { 7, (note, x, y) => (y < note.y && x >= note.x) || (y <= note.y && x > note.x) || (y == note.y && x == note.x) },
+        { 8, (note, x, y) => false }
+    };
 
     public Parity ParityCheck(BeatCutData lastCut, ref BeatCutData currentSwing, List<BombNote> bombs, float playerXOffset, bool rightHand)
     {
@@ -16,23 +31,58 @@ public class ResetParityCheck : IParityMethod
 
         ColourNote nextNote = currentSwing.notesInCut[0];
 
-        var angleChange = (lastCut.sliceParity != Parity.Forehand) ?
-            SliceMap.BackhandDict[lastCut.notesInCut[0].d] - SliceMap.ForehandDict[nextNote.d] :
-            SliceMap.ForehandDict[lastCut.notesInCut[0].d] - SliceMap.BackhandDict[nextNote.d];
+        float angleChange = 0;
+        float currentAFN = (lastCut.sliceParity != Parity.Forehand) ?
+            SliceMap.BackhandDict[lastCut.notesInCut[0].d] :
+            SliceMap.ForehandDict[lastCut.notesInCut[0].d];
+        float nextAFN = (lastCut.sliceParity != Parity.Forehand) ?
+            SliceMap.BackhandDict[nextNote.d] :
+            SliceMap.ForehandDict[nextNote.d];
+
+        angleChange = currentAFN - nextAFN;
 
         #region Bomb Reset Checks
 
-        // Checks if either bomb reset bomb locations exist
-        var bombCheckLayer = (lastCut.sliceParity == Parity.Forehand) ? 0 : 2;
-        bool containsRightmost = bombs.FindIndex(x => x.x == 2 + playerXOffset && x.y == bombCheckLayer) != -1;
-        bool containsLeftmost = bombs.FindIndex(x => x.x == 1 + playerXOffset && x.y == bombCheckLayer) != -1;
-
-        // If there is a bomb, potentially a bomb reset
-        if ((!rightHand && containsLeftmost) || (rightHand && containsRightmost))
+        // Structured so that successive bombs (for example, in a spiral) can be accounted for to some degree.
+        // Alternates the orientation each time so if bombs appear in the opposite spots, it flips
+        bool bombReset = false;
+        for (int i = 0; i < bombs.Count; i++)
         {
-            List<int> resetDirectionList = (lastCut.sliceParity == Parity.Forehand) ? SliceMap.forehandResetDict : SliceMap.backhandResetDict;
-            if (resetDirectionList.Contains(lastCut.notesInCut[0].d))
+            // Get current bomb
+            BombNote bomb = bombs[i];
+            ColourNote note;
+
+            // Get the last note. In the case of a stack, picks the note that isnt at 2 or 0 as
+            // it triggers a reset when it shouldn't.
+            note = lastCut.notesInCut[^1];
+            if (lastCut.notesInCut.Count > 1)
             {
+                if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Forehand)
+                {
+                    note = lastCut.notesInCut.First(x => x.y != 0);
+                }
+                else if (lastCut.endPositioning.angle == 0 && lastCut.sliceParity == Parity.Backhand)
+                {
+                    note = lastCut.notesInCut.First(x => x.y != 2);
+                }
+            }
+
+            // Get the last notes cut direction based on the last swings angle
+            var lastNoteCutDir = (lastCut.sliceParity == Parity.Forehand) ?
+                SliceMap.ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key :
+                SliceMap.BackhandDict.FirstOrDefault(x => x.Value == Math.Round(lastCut.endPositioning.angle / 45.0) * 45).Key;
+
+            // Use the dictionary to determine if a reset should be called given bomb position and note position
+            bombReset = _bombDetectionConditions[lastNoteCutDir](note, bomb.x, bomb.y);
+            if (bombReset) break;
+        }
+
+        if (bombReset)
+        {
+            // TEMP: This IF statement seemed to help catch dot spirals for now, but probably causes issues somewhere
+            if ((rightHand && nextAFN > -180) || (!rightHand && nextAFN < 180))
+            {
+                // Set as bomb reset and return same parity as last swing
                 currentSwing.resetType = ResetType.Bomb;
                 return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
             }

--- a/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
@@ -9,17 +9,19 @@ public class ResetParityCheck : IParityMethod
     private bool _upsideDown;
 
     // Returns true if the inputted note and bomb coordinates cause a reset potentially
-    private Dictionary<int, Func<Vector2, int, int, bool>> _bombDetectionConditions = new()
+    private Dictionary<int, Func<Vector2, int, int, Parity, bool>> _bombDetectionConditions = new()
     {
-        { 0, (note, x, y) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
-        { 1, (note, x, y) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
-        { 2, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x <= note.x },
-        { 3, (note, x, y) => ((y == note.y) || (y == note.y - 1)) && x >= note.x },
-        { 4, (note, x, y) => y == note.y && x == note.x && y != 0 },
-        { 5, (note, x, y) => y == note.y && x == note.x && y != 0 },
-        { 6, (note, x, y) => x == note.x && y == note.y && y != 2 },
-        { 7, (note, x, y) => x == note.x && y == note.y && y != 2 },
-        { 8, (note, x, y) => false }
+        { 0, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 1, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 2, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) ||
+            (parity == Parity.Backhand && y == note.y && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) },
+        { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) ||
+            (parity == Parity.Backhand && y == note.y && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) },
+        { 4, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 5, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
+        { 6, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 7, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 8, (note,x,y, parity) => false }
     };
 
     public bool BombResetCheck(BeatCutData lastCut, List<BombNote> bombs)

--- a/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/ResetParityCheck.cs
@@ -6,13 +6,16 @@ public class ResetParityCheck : IParityMethod
     public bool UpsideDown { get { return _upsideDown; } }
     private bool _upsideDown;
 
-    public Parity ParityCheck(BeatCutData lastCut, ColourNote nextNote, List<BombNote> bombs, float playerXOffset, bool rightHand)
+    public Parity ParityCheck(BeatCutData lastCut, ref BeatCutData currentSwing, List<BombNote> bombs, float playerXOffset, bool rightHand)
     {
         // AFN: Angle from neutral
         // Assuming a forehand down hit is neutral, and a backhand up hit
         // Rotating the hand inwards goes positive, and outwards negative
         // Using a list of definitions, turn cut direction into an angle, and check
         // if said angle makes sense.
+
+        ColourNote nextNote = currentSwing.notesInCut[0];
+
         var angleChange = (lastCut.sliceParity != Parity.Forehand) ?
             SliceMap.BackhandDict[lastCut.notesInCut[0].d] - SliceMap.ForehandDict[nextNote.d] :
             SliceMap.ForehandDict[lastCut.notesInCut[0].d] - SliceMap.BackhandDict[nextNote.d];
@@ -30,6 +33,7 @@ public class ResetParityCheck : IParityMethod
             List<int> resetDirectionList = (lastCut.sliceParity == Parity.Forehand) ? SliceMap.forehandResetDict : SliceMap.backhandResetDict;
             if (resetDirectionList.Contains(lastCut.notesInCut[0].d))
             {
+                currentSwing.resetType = ResetType.Bomb;
                 return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
             }
         }
@@ -44,6 +48,7 @@ public class ResetParityCheck : IParityMethod
         // If the angle change exceeds 180 then triangle
         if (Mathf.Abs(angleChange) > 90)
         {
+            currentSwing.resetType = ResetType.Normal;
             return (lastCut.sliceParity == Parity.Forehand) ? Parity.Forehand : Parity.Backhand;
         }
         else { return (lastCut.sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand; }

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -259,6 +259,7 @@ public class SliceMap
         // Add empty swings in for bomb avoidance.
         // Replace later with more advanced movement to avoid bombs in general.
         result = AddBombResetAvoidance(result);
+        Debug.Log("Right Hand: " + _rightHand + " | Resets: " + result.Count(x => x.resetType == ResetType.Normal));
         return result;
     }
 
@@ -373,7 +374,7 @@ public class SliceMap
                 BeatCutData emptySwing = new BeatCutData();
                 emptySwing.sliceParity = (swings[i].sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
                 emptySwing.sliceStartBeat = swings[i - 1].sliceEndBeat + SecondsToBeats(_BPM, 0.15f);
-                emptySwing.sliceEndBeat = emptySwing.sliceStartBeat + 0.5f;
+                emptySwing.sliceEndBeat = emptySwing.sliceStartBeat + 0.2f;
                 emptySwing.SetStartPosition(lastNote.x, lastNote.y);
 
                 // If the last hit was a dot, pick the opposing direction based on parity.
@@ -409,7 +410,7 @@ public class SliceMap
 
     #region Helper Functions
     // Given a cut direction ID, return angle from appropriate dictionary
-    private float AngleGivenCutDirection(int cutDirection, Parity parity)
+    public static float AngleGivenCutDirection(int cutDirection, Parity parity)
     {
         return (parity == Parity.Forehand) ? ForehandDict[cutDirection] : BackhandDict[cutDirection];
     }

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -271,26 +271,26 @@ public class SliceMap
     public BeatCutData DotChecks(BeatCutData currentSwing, BeatCutData lastSwing)
     {
         // If the entire swing is dots
-        if(currentSwing.notesInCut.Count(x => x.d == 8) == currentSwing.notesInCut.Count)
+        if(currentSwing.notesInCut.All(x => x.d == 8))
         {
             // If there is more then 1 note, indicating a dot stack, tower, or zebra slider
             if (currentSwing.notesInCut.Count > 1)
             {
-                // Check which note is closer from last swing
-                // Depending on which is closer, calculate angle
-                Vector2 lastSwingVec = LevelUtils.GetWorldXYFromBeatmapCoords(lastSwing.notesInCut[^1].x, lastSwing.notesInCut[^1].y);
-                Vector2 firstNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[0].x, currentSwing.notesInCut[0].y);
-                Vector2 lastNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[^1].x, currentSwing.notesInCut[^1].y);
+                float angle;
+                float firstToLast = AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
+                float lastToFirst = AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]);
+                if (currentSwing.notesInCut.All(x => x.b == currentSwing.notesInCut[0].b))
+                {
+                    float currentAngle = lastSwing.endPositioning.angle;
 
-                float distanceToStart = Vector2.Distance(firstNoteVec, lastSwingVec);
-                float distanceToEnd = Vector2.Distance(lastNoteVec, lastSwingVec);
+                    float FTLChange = currentAngle - firstToLast;
+                    float LTFChange = currentAngle - lastToFirst;
 
-                if (distanceToStart > distanceToEnd) {
-                    currentSwing.notesInCut.Reverse();
+                    if (Mathf.Abs(FTLChange) < Mathf.Abs(LTFChange)) { angle = firstToLast; } else { angle = lastToFirst; }
+                } else {
+                    angle = firstToLast;
                 }
 
-                var angle = AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]);
-                if(angle > 0 && lastSwing.sliceParity == Parity.Forehand) { angle -= 180; }
                 currentSwing.SetStartAngle(angle);
                 currentSwing.sliceStartBeat = currentSwing.notesInCut[0].b;
                 currentSwing.sliceEndBeat = currentSwing.notesInCut[^1].b + 0.1f;

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -406,6 +406,7 @@ public class SliceMap
                         result[i + swingsAdded] = postResetSwing;
                     }
                 }
+
                 result.Insert(i + swingsAdded, emptySwing);
                 swingsAdded++;
             }

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -76,7 +76,7 @@ public class SliceMap
     { { 0, 1 }, { 1, 0 }, { 2, 3 }, { 3, 2 }, { 4, 7 }, { 7, 4 }, { 5, 6 }, { 6, 5 } };
 
     public static readonly List<int> forehandResetDict = new List<int>()
-    { 1, 6, 7 };
+    { 1, 2, 3, 6, 7 };
     public static readonly List<int> backhandResetDict = new List<int>()
     { 0, 4, 5 };
 
@@ -396,13 +396,14 @@ public class SliceMap
                 emptySwing.SetEndPosition((int)endPosition.x, (int)endPosition.y);
 
                 // If swing after reset is a singular dot note, Then based on parity set its swing direction
-                if (swings[i + 1].notesInCut[0].d == 8 && swings[i + 2].notesInCut.Count == 1)
+                if (swings[i+swingsAdded].notesInCut[0].d == 8 && swings[i + swingsAdded].notesInCut.Count == 1)
                 {
                     if (emptySwing.sliceParity == Parity.Backhand)
                     {
-                        BeatCutData postResetSwing = result[i + 2];
+                        BeatCutData postResetSwing = result[i + swingsAdded];
                         postResetSwing.SetStartAngle(0);
-                        result[i + 2] = postResetSwing;
+                        postResetSwing.SetEndAngle(0);
+                        result[i + swingsAdded] = postResetSwing;
                     }
                 }
                 result.Insert(i + swingsAdded, emptySwing);

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -266,11 +266,12 @@ public class SliceMap
     // Modifies a Swing if Dot Notes are involved
     public BeatCutData DotChecks(BeatCutData currentSwing, BeatCutData lastSwing)
     {
-        // If the start and end notes are dots
-        if(currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[^1].d == 8)
+        // If the entire swing is dots
+        if(currentSwing.notesInCut.Count(x => x.d == 8) == currentSwing.notesInCut.Count)
         {
             // If there is more then 1 note, indicating a dot stack, tower, or zebra slider
-            if (currentSwing.notesInCut.Count > 1) {
+            if (currentSwing.notesInCut.Count > 1)
+            {
                 // Check which note is closer from last swing
                 // Depending on which is closer, calculate angle
                 Vector2 lastSwingVec = LevelUtils.GetWorldXYFromBeatmapCoords(lastSwing.notesInCut[0].x, lastSwing.notesInCut[0].y);
@@ -286,7 +287,8 @@ public class SliceMap
                     AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
                 currentSwing.SetStartAngle(angle);
 
-                if (distanceToStart > distanceToEnd) {
+                if (distanceToStart > distanceToEnd)
+                {
                     currentSwing.notesInCut.Reverse();
                     angle = (currentSwing.sliceParity == Parity.Forehand) ?
                         AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]) :
@@ -394,18 +396,6 @@ public class SliceMap
                 Vector3 dir = Quaternion.Euler(0, 0, emptySwing.startPositioning.angle) * Vector3.up;
                 Vector2 endPosition = new Vector2(dir.x * 2f, dir.y * 2f);
                 emptySwing.SetEndPosition((int)endPosition.x, (int)endPosition.y);
-
-                // If swing after reset is a singular dot note, Then based on parity set its swing direction
-                if (swings[i+swingsAdded].notesInCut[0].d == 8 && swings[i + swingsAdded].notesInCut.Count == 1)
-                {
-                    if (emptySwing.sliceParity == Parity.Backhand)
-                    {
-                        BeatCutData postResetSwing = result[i + swingsAdded];
-                        postResetSwing.SetStartAngle(0);
-                        postResetSwing.SetEndAngle(0);
-                        result[i + swingsAdded] = postResetSwing;
-                    }
-                }
 
                 result.Insert(i + swingsAdded, emptySwing);
                 swingsAdded++;

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -7,8 +7,16 @@ public enum Parity
 {
     None,
     Forehand,
-    Backhand,
-    Reset
+    Backhand
+}
+
+[System.Serializable]
+public enum ResetType
+{
+    None,
+    Normal,
+    Bomb,
+    Roll
 }
 
 [System.Serializable]
@@ -23,14 +31,22 @@ public struct PositioningData
 public struct BeatCutData
 {
     public Parity sliceParity;
+    public ResetType resetType;
     public float sliceStartBeat;
     public float sliceEndBeat;
     public float swingEBPM;
+    public bool isInverted;
+    public List<ColourNote> notesInCut;
+
+    public void SetStartPosition(int x, int y) { startPositioning.x = x; endPositioning.y = y; }
+    public void SetEndPosition(int x, int y) { endPositioning.x = x; endPositioning.y = y; }
+    public void SetStartAngle(float angle) { startPositioning.angle = angle; }
+    public void SetEndAngle(float angle) { endPositioning.angle = angle; }
+    public bool IsReset { get { return resetType != 0; } }
+
     public PositioningData startPositioning;
     public PositioningData endPositioning;
-    public List<ColourNote> notesInCut;
-    public bool isReset;
-    public bool isInverted;
+
 }
 
 // Adapted from Joshabi's ParityChecker
@@ -135,7 +151,7 @@ public class SliceMap
             // If precision falls under "Slider", or time stamp is the same, run
             // checks to figure out if it is a slider, window, stack ect..
             if (Mathf.Abs(currentNote.b - nextNote.b) <= sliderPrecision) {
-                if (nextNote.d == 8 || notesInSwing[notesInSwing.Count-1].d == 8 ||
+                if (nextNote.d == 8 || notesInSwing[^1].d == 8 ||
                     currentNote.d == nextNote.d || Mathf.Abs(ForehandDict[currentNote.d] - ForehandDict[nextNote.d]) <= 45 ||
                      Mathf.Abs(BackhandDict[currentNote.d] - BackhandDict[nextNote.d]) <= 45)
                     { continue; }
@@ -146,20 +162,18 @@ public class SliceMap
             sData.notesInCut = new List<ColourNote>(notesInSwing);
             sData.sliceParity = Parity.Forehand;
             sData.sliceStartBeat = notesInSwing[0].b;
-            sData.sliceEndBeat = notesInSwing[notesInSwing.Count - 1].b + 0.1f;
-            sData.startPositioning.angle = ForehandDict[notesInSwing[0].d];
-            sData.startPositioning.x = notesInSwing[0].x;
-            sData.startPositioning.y = notesInSwing[0].y;
-            sData.endPositioning.angle = ForehandDict[notesInSwing[notesInSwing.Count-1].d];
-            sData.endPositioning.x = notesInSwing[notesInSwing.Count-1].x;
-            sData.endPositioning.y = notesInSwing[notesInSwing.Count-1].y;
+            sData.sliceEndBeat = notesInSwing[^1].b + 0.1f;
+            sData.SetStartPosition(notesInSwing[0].x, notesInSwing[0].y);
+            sData.SetStartAngle(ForehandDict[notesInSwing[0].d]);
+            sData.SetEndPosition(notesInSwing[^1].x, notesInSwing[^1].y);
+            sData.SetEndAngle(ForehandDict[notesInSwing[^1].d]);
 
             // If first swing, figure out starting orientation based on cut direction
             if (result.Count == 0) {
                 if (currentNote.d == 0 || currentNote.d == 4 || currentNote.d == 5) {
                     sData.sliceParity = Parity.Backhand;
-                    sData.startPositioning.angle = BackhandDict[notesInSwing[0].d];
-                    sData.endPositioning.angle = BackhandDict[notesInSwing[notesInSwing.Count - 1].d]; 
+                    sData.SetStartAngle(BackhandDict[notesInSwing[0].d]);
+                    sData.SetEndAngle(BackhandDict[notesInSwing[^1].d]);
                 }
                 result.Add(sData);
                 notesInSwing.Clear();
@@ -167,15 +181,15 @@ public class SliceMap
             }
 
             // If previous swing exists
-            BeatCutData lastSwing = result[result.Count - 1];
-            ColourNote lastNote = lastSwing.notesInCut[lastSwing.notesInCut.Count - 1];
+            BeatCutData lastSwing = result[^1];
+            ColourNote lastNote = lastSwing.notesInCut[^1];
 
             // Performs Dot Checks under the assumption is a forehand swing
             sData = DotChecks(sData, lastSwing);
 
             // Get swing EBPM, if reset then double
             sData.swingEBPM = SwingEBPM(_BPM, currentNote.b - lastNote.b);
-            if (sData.isReset) { sData.swingEBPM *= 2; }
+            if (sData.IsReset) { sData.swingEBPM *= 2; }
 
             // Invert Check
             if (sData.isInverted == false)
@@ -194,7 +208,7 @@ public class SliceMap
             }
 
             // Work out current player XOffset for bomb calculations
-            List<Obstacle> wallsInBetween = walls.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[notesInSwing.Count - 1].b);
+            List<Obstacle> wallsInBetween = walls.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[^1].b);
             if(wallsInBetween.Count != 0) {
                 foreach(Obstacle wall in wallsInBetween)
                 {
@@ -210,30 +224,30 @@ public class SliceMap
 
             // If time since dodged exceeds a set amount in seconds, undo dodge
             var undodgeCheckTime = 0.35f;
-            if (BeatToSeconds(_BPM, notesInSwing[notesInSwing.Count-1].b - _lastWallTime) > undodgeCheckTime) { _playerXOffset = 0; }
+            if (BeatToSeconds(_BPM, notesInSwing[^1].b - _lastWallTime) > undodgeCheckTime) { _playerXOffset = 0; }
 
             // Work out Parity
-            List<BombNote> bombsBetweenSwings = bombs.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[notesInSwing.Count - 1].b);
+            List<BombNote> bombsBetweenSwings = bombs.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[^1].b);
             sData.sliceParity = _parityMethodology.ParityCheck(lastSwing, notesInSwing[0], bombsBetweenSwings, _playerXOffset, _rightHand);
 
             // If backhand, readjust start and end angle
             if (sData.sliceParity == Parity.Backhand) {
-                sData.startPositioning.angle = BackhandDict[notesInSwing[0].d];
-                sData.endPositioning.angle = BackhandDict[notesInSwing[notesInSwing.Count - 1].d];
-                sData = DotChecks(sData, result[result.Count - 1]);
+                sData.SetStartAngle(BackhandDict[notesInSwing[0].d]);
+                sData.SetEndAngle(BackhandDict[notesInSwing[^1].d]);
+                sData = DotChecks(sData, result[^1]);
             }
 
             // If dot, re-orientate
             if (sData.notesInCut[0].d == 8 && sData.notesInCut.Count == 1) sData = FixDotOrientation(lastSwing, sData);
 
             // If parity is the same as before, this is a reset.
-            if (sData.sliceParity == lastSwing.sliceParity) { sData.isReset = true; }
+            if (sData.sliceParity == lastSwing.sliceParity && sData.resetType != ResetType.Bomb) { sData.resetType = ResetType.Normal; }
 
             // If current parity method thinks we are upside down, flip values.
             if (_parityMethodology.UpsideDown == true)
             {
-                sData.startPositioning.angle *= -1;
-                sData.endPositioning.angle *= -1;
+                sData.SetStartAngle(sData.startPositioning.angle * -1);
+                sData.SetEndAngle(sData.endPositioning.angle * -1);
             }
 
             // Add swing to list
@@ -251,7 +265,7 @@ public class SliceMap
     public BeatCutData DotChecks(BeatCutData currentSwing, BeatCutData lastSwing)
     {
         // If the start and end notes are dots
-        if(currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[currentSwing.notesInCut.Count-1].d == 8)
+        if(currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[^1].d == 8)
         {
             // If there is more then 1 note, indicating a dot stack, tower, or zebra slider
             if (currentSwing.notesInCut.Count > 1) {
@@ -259,42 +273,42 @@ public class SliceMap
                 // Depending on which is closer, calculate angle
                 Vector2 lastSwingVec = LevelUtils.GetWorldXYFromBeatmapCoords(lastSwing.notesInCut[0].x, lastSwing.notesInCut[0].y);
                 Vector2 firstNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[0].x, currentSwing.notesInCut[0].y);
-                Vector2 lastNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[currentSwing.notesInCut.Count-1].x, currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].y);
+                Vector2 lastNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[^1].x, currentSwing.notesInCut[^1].y);
 
                 float distanceToStart = Vector2.Distance(firstNoteVec, lastSwingVec);
                 float distanceToEnd = Vector2.Distance(lastNoteVec, lastSwingVec);
 
                 // Depending on Parity, calculate the cut direction of the dot stack
-                currentSwing.startPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                    AngleBetweenNotes(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1], currentSwing.notesInCut[0]) :
-                    AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[currentSwing.notesInCut.Count - 1]);
+                float angle = (currentSwing.sliceParity == Parity.Forehand) ?
+                    AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]) :
+                    AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
+                currentSwing.SetStartAngle(angle);
 
                 if (distanceToStart > distanceToEnd) {
                     currentSwing.notesInCut.Reverse();
-                    currentSwing.startPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                        AngleBetweenNotes(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1], currentSwing.notesInCut[0]) :
-                        AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[currentSwing.notesInCut.Count - 1]);
+                    angle = (currentSwing.sliceParity == Parity.Forehand) ?
+                        AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]) :
+                        AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
+                    currentSwing.SetStartAngle(angle);
                     currentSwing.sliceStartBeat = currentSwing.notesInCut[0].b;
-                    currentSwing.sliceEndBeat = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].b + 0.1f;
-                    currentSwing.startPositioning.x = currentSwing.notesInCut[0].x;
-                    currentSwing.startPositioning.y = currentSwing.notesInCut[0].y;
-                    currentSwing.endPositioning.x = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].x;
-                    currentSwing.endPositioning.y = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].y;
+                    currentSwing.sliceEndBeat = currentSwing.notesInCut[^1].b + 0.1f;
+                    currentSwing.SetStartPosition(currentSwing.notesInCut[0].x, currentSwing.notesInCut[0].y);
+                    currentSwing.SetEndPosition(currentSwing.notesInCut[^1].x, currentSwing.notesInCut[^1].y);
                 }
 
                 // Can possibly remove? Fixes weird backhand down stack hits for the right hand? Not sure why
-                if (currentSwing.startPositioning.angle == 180 && _rightHand) currentSwing.startPositioning.angle *= -1;
+                if (currentSwing.startPositioning.angle == 180 && _rightHand) currentSwing.SetStartAngle(currentSwing.startPositioning.angle * -1);
 
                 // Set ending angle equal to starting angle
-                currentSwing.endPositioning.angle = currentSwing.startPositioning.angle;
-
+                currentSwing.SetEndAngle(currentSwing.startPositioning.angle);
             }
-        } else if (currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[currentSwing.notesInCut.Count-1].d != 8) {
+        } else if (currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[^1].d != 8) {
             // In the event its a dot then an arrow
-            currentSwing.startPositioning.angle = AngleGivenCutDirection(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d, currentSwing.sliceParity);
-            currentSwing.endPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                ForehandDict[currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d] :
-                BackhandDict[currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d];
+            currentSwing.SetStartAngle(AngleGivenCutDirection(currentSwing.notesInCut[^1].d, currentSwing.sliceParity));
+            float angle = (currentSwing.sliceParity == Parity.Forehand) ?
+                ForehandDict[currentSwing.notesInCut[^1].d] :
+                BackhandDict[currentSwing.notesInCut[^1].d];
+            currentSwing.SetEndAngle(angle);
         }
         return currentSwing;
     }
@@ -303,14 +317,15 @@ public class SliceMap
     private BeatCutData FixDotOrientation(BeatCutData lastSwing, BeatCutData currentSwing)
     {
         // Get the previous and current notes
-        ColourNote lastNote = lastSwing.notesInCut[lastSwing.notesInCut.Count - 1];
+        ColourNote lastNote = lastSwing.notesInCut[^1];
         ColourNote currentNote = currentSwing.notesInCut[0];
 
         if (lastNote.d != 8) {
-            currentSwing.startPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
+            float angle = (currentSwing.sliceParity == Parity.Forehand) ?
                 AngleGivenCutDirection(opposingCutDict[lastNote.d], Parity.Forehand) :
-                AngleGivenCutDirection(opposingCutDict[lastNote.d], Parity.Backhand) ;
-            currentSwing.endPositioning.angle = currentSwing.startPositioning.angle;
+                AngleGivenCutDirection(opposingCutDict[lastNote.d], Parity.Backhand);
+            currentSwing.SetStartAngle(angle);
+            currentSwing.SetEndAngle(angle);
         } else {
             // If the notes are on the same layer, generate the angle based on the end and starting hand positions
             Vector2 lastHandCoords = new Vector2(lastSwing.endPositioning.x, lastSwing.endPositioning.y);
@@ -328,8 +343,8 @@ public class SliceMap
             angle = Mathf.Clamp(angle, -90, 90);
             if (currentNote.y != lastNote.y) angle = Mathf.Clamp(angle, -45, 45);
 
-            currentSwing.startPositioning.angle = angle;
-            currentSwing.endPositioning.angle = angle;
+            currentSwing.SetStartAngle(angle);
+            currentSwing.SetEndAngle(angle);
         }
         return currentSwing;
     }
@@ -344,40 +359,38 @@ public class SliceMap
 
         for (int i = 0; i < swings.Count - 1; i++)
         {
-            if (swings[i].isReset)
+            if (swings[i].resetType == ResetType.Bomb)
             {
                 // Reference to last swing
-                ColourNote lastNote = swings[i - 1].notesInCut[swings[i - 1].notesInCut.Count - 1];
+                ColourNote lastNote = swings[i - 1].notesInCut[^1];
 
                 // Create a new swing with inverse parity to the last.
                 BeatCutData emptySwing = new BeatCutData();
                 emptySwing.sliceParity = (swings[i].sliceParity == Parity.Forehand) ? Parity.Backhand : Parity.Forehand;
                 emptySwing.sliceStartBeat = swings[i - 1].sliceEndBeat + SecondsToBeats(_BPM, 0.1f);
                 emptySwing.sliceEndBeat = emptySwing.sliceStartBeat + 0.2f;
-                emptySwing.startPositioning.x = lastNote.x;
-                emptySwing.startPositioning.y = lastNote.y;
+                emptySwing.SetStartPosition(lastNote.x, lastNote.y);
 
                 // If the last hit was a dot, pick the opposing direction based on parity.
-                if (lastNote.d == 8)
-                {
-                    emptySwing.startPositioning.angle = (emptySwing.sliceParity == Parity.Forehand) ?
+                float angle = 0;
+                if (lastNote.d == 8) {
+                    angle = (emptySwing.sliceParity == Parity.Forehand) ?
                         ForehandDict[1] : BackhandDict[0];
-                }
-                else
-                {
+                } else {
                     // If the last hit was arrowed, figure out the opposing cut direction and use that.
-                    emptySwing.startPositioning.angle = (emptySwing.sliceParity == Parity.Forehand) ?
+                    angle = (emptySwing.sliceParity == Parity.Forehand) ?
                         ForehandDict[opposingCutDict[lastNote.d]] :
                         BackhandDict[opposingCutDict[lastNote.d]];
                 }
-                // End angle should be the same as the start angle
-                emptySwing.endPositioning.angle = emptySwing.startPositioning.angle;
+
+                // Set start and end angle, should be the same
+                emptySwing.SetStartAngle(angle);
+                emptySwing.SetEndAngle(angle);
 
                 // Calculate the direction, set it, then insert this swing into the returned result list.
                 Vector3 dir = Quaternion.Euler(0, 0, emptySwing.startPositioning.angle) * Vector3.up;
                 Vector2 endPosition = new Vector2(dir.x * 2f, dir.y * 2f);
-                emptySwing.endPositioning.x = (int)endPosition.x;
-                emptySwing.endPositioning.y = (int)endPosition.y;
+                emptySwing.SetEndPosition((int)endPosition.x, (int)endPosition.y);
 
                 // If swing after reset is a singular dot note, Then based on parity set its swing direction
                 if (swings[i + 1].notesInCut[0].d == 8 && swings[i + 2].notesInCut.Count == 1)
@@ -385,7 +398,7 @@ public class SliceMap
                     if (emptySwing.sliceParity == Parity.Backhand)
                     {
                         BeatCutData postResetSwing = result[i + 2];
-                        postResetSwing.startPositioning.angle = 0;
+                        postResetSwing.SetStartAngle(0);
                         result[i + 2] = postResetSwing;
                     }
                 }

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -135,7 +135,7 @@ public class SliceMap
             // If precision falls under "Slider", or time stamp is the same, run
             // checks to figure out if it is a slider, window, stack ect..
             if (Mathf.Abs(currentNote.b - nextNote.b) <= sliderPrecision) {
-                if (nextNote.d == 8 || notesInSwing[notesInSwing.Count-1].d == 8 ||
+                if (nextNote.d == 8 || notesInSwing[^1].d == 8 ||
                     currentNote.d == nextNote.d || Mathf.Abs(ForehandDict[currentNote.d] - ForehandDict[nextNote.d]) <= 45 ||
                      Mathf.Abs(BackhandDict[currentNote.d] - BackhandDict[nextNote.d]) <= 45)
                     { continue; }
@@ -146,11 +146,11 @@ public class SliceMap
             sData.notesInCut = new List<ColourNote>(notesInSwing);
             sData.sliceParity = Parity.Forehand;
             sData.sliceStartBeat = notesInSwing[0].b;
-            sData.sliceEndBeat = notesInSwing[notesInSwing.Count - 1].b + 0.1f;
+            sData.sliceEndBeat = notesInSwing[^1].b + 0.1f;
             sData.startPositioning.angle = ForehandDict[notesInSwing[0].d];
             sData.startPositioning.x = notesInSwing[0].x;
             sData.startPositioning.y = notesInSwing[0].y;
-            sData.endPositioning.angle = ForehandDict[notesInSwing[notesInSwing.Count-1].d];
+            sData.endPositioning.angle = ForehandDict[notesInSwing[^1].d];
             sData.endPositioning.x = notesInSwing[notesInSwing.Count-1].x;
             sData.endPositioning.y = notesInSwing[notesInSwing.Count-1].y;
 
@@ -159,7 +159,7 @@ public class SliceMap
                 if (currentNote.d == 0 || currentNote.d == 4 || currentNote.d == 5) {
                     sData.sliceParity = Parity.Backhand;
                     sData.startPositioning.angle = BackhandDict[notesInSwing[0].d];
-                    sData.endPositioning.angle = BackhandDict[notesInSwing[notesInSwing.Count - 1].d]; 
+                    sData.endPositioning.angle = BackhandDict[notesInSwing[^1].d]; 
                 }
                 result.Add(sData);
                 notesInSwing.Clear();
@@ -167,8 +167,8 @@ public class SliceMap
             }
 
             // If previous swing exists
-            BeatCutData lastSwing = result[result.Count - 1];
-            ColourNote lastNote = lastSwing.notesInCut[lastSwing.notesInCut.Count - 1];
+            BeatCutData lastSwing = result[^1];
+            ColourNote lastNote = lastSwing.notesInCut[^1];
 
             // Performs Dot Checks under the assumption is a forehand swing
             sData = DotChecks(sData, lastSwing);
@@ -194,7 +194,7 @@ public class SliceMap
             }
 
             // Work out current player XOffset for bomb calculations
-            List<Obstacle> wallsInBetween = walls.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[notesInSwing.Count - 1].b);
+            List<Obstacle> wallsInBetween = walls.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[^1].b);
             if(wallsInBetween.Count != 0) {
                 foreach(Obstacle wall in wallsInBetween)
                 {
@@ -213,14 +213,14 @@ public class SliceMap
             if (BeatToSeconds(_BPM, notesInSwing[notesInSwing.Count-1].b - _lastWallTime) > undodgeCheckTime) { _playerXOffset = 0; }
 
             // Work out Parity
-            List<BombNote> bombsBetweenSwings = bombs.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[notesInSwing.Count - 1].b);
+            List<BombNote> bombsBetweenSwings = bombs.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[^1].b);
             sData.sliceParity = _parityMethodology.ParityCheck(lastSwing, notesInSwing[0], bombsBetweenSwings, _playerXOffset, _rightHand);
 
             // If backhand, readjust start and end angle
             if (sData.sliceParity == Parity.Backhand) {
                 sData.startPositioning.angle = BackhandDict[notesInSwing[0].d];
-                sData.endPositioning.angle = BackhandDict[notesInSwing[notesInSwing.Count - 1].d];
-                sData = DotChecks(sData, result[result.Count - 1]);
+                sData.endPositioning.angle = BackhandDict[notesInSwing[^1].d];
+                sData = DotChecks(sData, result[^1]);
             }
 
             // If dot, re-orientate
@@ -259,27 +259,27 @@ public class SliceMap
                 // Depending on which is closer, calculate angle
                 Vector2 lastSwingVec = LevelUtils.GetWorldXYFromBeatmapCoords(lastSwing.notesInCut[0].x, lastSwing.notesInCut[0].y);
                 Vector2 firstNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[0].x, currentSwing.notesInCut[0].y);
-                Vector2 lastNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[currentSwing.notesInCut.Count-1].x, currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].y);
+                Vector2 lastNoteVec = LevelUtils.GetWorldXYFromBeatmapCoords(currentSwing.notesInCut[^1].x, currentSwing.notesInCut[^1].y);
 
                 float distanceToStart = Vector2.Distance(firstNoteVec, lastSwingVec);
                 float distanceToEnd = Vector2.Distance(lastNoteVec, lastSwingVec);
 
                 // Depending on Parity, calculate the cut direction of the dot stack
                 currentSwing.startPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                    AngleBetweenNotes(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1], currentSwing.notesInCut[0]) :
-                    AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[currentSwing.notesInCut.Count - 1]);
+                    AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]) :
+                    AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
 
                 if (distanceToStart > distanceToEnd) {
                     currentSwing.notesInCut.Reverse();
                     currentSwing.startPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                        AngleBetweenNotes(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1], currentSwing.notesInCut[0]) :
-                        AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[currentSwing.notesInCut.Count - 1]);
+                        AngleBetweenNotes(currentSwing.notesInCut[^1], currentSwing.notesInCut[0]) :
+                        AngleBetweenNotes(currentSwing.notesInCut[0], currentSwing.notesInCut[^1]);
                     currentSwing.sliceStartBeat = currentSwing.notesInCut[0].b;
-                    currentSwing.sliceEndBeat = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].b + 0.1f;
+                    currentSwing.sliceEndBeat = currentSwing.notesInCut[^1].b + 0.1f;
                     currentSwing.startPositioning.x = currentSwing.notesInCut[0].x;
                     currentSwing.startPositioning.y = currentSwing.notesInCut[0].y;
-                    currentSwing.endPositioning.x = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].x;
-                    currentSwing.endPositioning.y = currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].y;
+                    currentSwing.endPositioning.x = currentSwing.notesInCut[^1].x;
+                    currentSwing.endPositioning.y = currentSwing.notesInCut[^1].y;
                 }
 
                 // Can possibly remove? Fixes weird backhand down stack hits for the right hand? Not sure why
@@ -291,10 +291,10 @@ public class SliceMap
             }
         } else if (currentSwing.notesInCut[0].d == 8 && currentSwing.notesInCut[currentSwing.notesInCut.Count-1].d != 8) {
             // In the event its a dot then an arrow
-            currentSwing.startPositioning.angle = AngleGivenCutDirection(currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d, currentSwing.sliceParity);
+            currentSwing.startPositioning.angle = AngleGivenCutDirection(currentSwing.notesInCut[^1].d, currentSwing.sliceParity);
             currentSwing.endPositioning.angle = (currentSwing.sliceParity == Parity.Forehand) ?
-                ForehandDict[currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d] :
-                BackhandDict[currentSwing.notesInCut[currentSwing.notesInCut.Count - 1].d];
+                ForehandDict[currentSwing.notesInCut[^1].d] :
+                BackhandDict[currentSwing.notesInCut[^1].d];
         }
         return currentSwing;
     }
@@ -303,7 +303,7 @@ public class SliceMap
     private BeatCutData FixDotOrientation(BeatCutData lastSwing, BeatCutData currentSwing)
     {
         // Get the previous and current notes
-        ColourNote lastNote = lastSwing.notesInCut[lastSwing.notesInCut.Count - 1];
+        ColourNote lastNote = lastSwing.notesInCut[^1];
         ColourNote currentNote = currentSwing.notesInCut[0];
 
         if (lastNote.d != 8) {
@@ -347,7 +347,7 @@ public class SliceMap
             if (swings[i].isReset)
             {
                 // Reference to last swing
-                ColourNote lastNote = swings[i - 1].notesInCut[swings[i - 1].notesInCut.Count - 1];
+                ColourNote lastNote = swings[i - 1].notesInCut[^1];
 
                 // Create a new swing with inverse parity to the last.
                 BeatCutData emptySwing = new BeatCutData();

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,167 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "ignore": false,
+        "defaultInstantiationMode": 1,
+        "supportsModification": true
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
TL:DR;
- Bomb reset logic is now determined by a dictionary that performs logic checks on the bomb and notes positions as well as parity.
- Dot Stack Logic has been reworked to favour the shortest angle change, then the shortest distance afterwards if the angle is the same
- Cleaned up code, removed some redundant flipping of angles.
- BeatCutData now has some functions to make it easier to modify the position and makes the code a bit tidier then having to change the X and Y individually. Didnt change much more then that as it would mess with classes other then SliceMap

Should still behave the same outside of a few weird edge cases.