### PR TITLE
Walls, Dots and Fly Wit Me

### DIFF
--- a/Assets/Materials/Wall.mat
+++ b/Assets/Materials/Wall.mat
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Wall
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 0.0047169924, b: 0.0047169924, a: 0.54509807}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Wall.mat.meta
+++ b/Assets/Materials/Wall.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48ae1675103685b4e975f3287dab9a50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Wall.prefab
+++ b/Assets/Prefabs/Wall.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &470783057152959951
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5000839773517504140}
+  - component: {fileID: 367102486854584629}
+  - component: {fileID: 4385654344061977546}
+  - component: {fileID: 109274644337107281}
+  - component: {fileID: 5056576690520091847}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5000839773517504140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470783057152959951}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.1823006, y: -0.05372238, z: -1.8252258}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &367102486854584629
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470783057152959951}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4385654344061977546
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470783057152959951}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 48ae1675103685b4e975f3287dab9a50, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &109274644337107281
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470783057152959951}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5056576690520091847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470783057152959951}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7b0d3777ccaf4644b4c810ac0115229, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _wall: {fileID: 0}
+  _wallColour: {r: 1, g: 0, b: 0, a: 0}
+  _timeToReachTarget: 0.4
+  _x: 0
+  _y: 0
+  _w: 0
+  _h: 0
+  _l: 0

--- a/Assets/Prefabs/Wall.prefab.meta
+++ b/Assets/Prefabs/Wall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 91a443e6a7128a441bd5ae3f03ce3789
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -521,6 +521,8 @@ MonoBehaviour:
     type: 3}
   _saberPrefab: {fileID: 3883014027810491326, guid: 82b6775e93e8c644fb9ec3d187e0ecf0,
     type: 3}
+  _wallPrefab: {fileID: 470783057152959951, guid: 91a443e6a7128a441bd5ae3f03ce3789,
+    type: 3}
   _bombPrefab: {fileID: 2055558874998763406, guid: fffb9d4a46b96ab4cadc16bb602eccfd,
     type: 3}
   _speed: 75
@@ -544,7 +546,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 028a8d0594ba28441ad266b4c6fc580b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _customLevelPath: Enter a map filepath here
+  _customLevelPath: Enter map file path here!
   _desiredDifficulty: 9
   _previewMap: 0
   _beatSaberMapIDCSV: 

--- a/Assets/Scripts/Core/LevelPreview.cs
+++ b/Assets/Scripts/Core/LevelPreview.cs
@@ -22,6 +22,7 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
     [SerializeField] private BeatmapData _beatmap;
     [SerializeField] private BeatCubeObject _cubePrefab;
     [SerializeField] private SaberController _saberPrefab;
+    [SerializeField] private GameObject _wallPrefab;
     [SerializeField] private GameObject _bombPrefab;
     [SerializeField] private float _speed = 100.0f;
     [SerializeField] private Color _leftColour;
@@ -46,6 +47,7 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
     private List<Obstacle> _obstacles = new List<Obstacle>();
     private int _blockIndex = 0;
     private int _bombIndex = 0;
+    private int _obstaclesIndex = 0;
 
     private SaberController _leftSaber;
     private SaberController _rightSaber;
@@ -73,6 +75,7 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
         _timeToReachSabers = Mathf.Abs((Mathf.Abs(_saberZ)-3.0f) / _speed);
         _blocks = new List<ColourNote>();
         _bombs = new List<BombNote>();
+        _obstacles = new List<Obstacle>();
         _goInstances = new List<GameObject>();
         _leftSaber = GameObject.Instantiate<SaberController>(_saberPrefab);
         _leftSaber.transform.position = Vector3.zero;
@@ -172,6 +175,7 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
 
         _blocks.Clear();
         _bombs.Clear();
+        _obstacles.Clear();
         _startBeatOffset = 2.0f;
         foreach (ColourNote block in _beatmap.BeatData.colorNotes)
         {
@@ -249,6 +253,18 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
                 }
             }
         }
+        if (_obstaclesIndex < _obstacles.Count)
+        {
+            while (_beatTime > _obstacles[_obstaclesIndex].b - _startBeatOffset)
+            {
+                Obstacle wall = _obstacles[_obstaclesIndex];
+                SpawnWall(wall.x, wall.y, wall.w, wall.h, wall.d);
+                ++_obstaclesIndex;
+                if (_obstaclesIndex >= _obstacles.Count) { break; }
+            }
+        }
+
+
         if (_leftSliceIndex < _sliceMapLeft.GetSliceCount())
         {
             BeatCutData cutData = _sliceMapLeft.GetBeatCutData(_leftSliceIndex);
@@ -346,7 +362,9 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
 
     public void SpawnWall(int x, int y, int w, int h, int d)
     {
-
+        BeatWallObject wall = GameObject.Instantiate(_wallPrefab).GetComponent<BeatWallObject>();
+        wall.Init(x, y, w, h, d, _speed, this);
+        _goInstances.Add(wall.gameObject);
     }
 
     public void SetTime(float t)
@@ -384,6 +402,18 @@ public class LevelPreview : MonoBehaviour, IRuntimeLevelContext
         if (_bombIndex == 0)
         {
             _bombIndex = _bombs.Count;
+        }
+        for (int i = 0; i < _obstacles.Count; ++i)
+        {
+            if (_obstacles[i].b > _beatTime)
+            {
+                _obstaclesIndex = i;
+                break;
+            }
+        }
+        if (_obstaclesIndex == 0)
+        {
+            _obstaclesIndex = _bombs.Count;
         }
 
         int numLeftCutData = _sliceMapLeft.GetSliceCount();

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -22,10 +22,10 @@ public class DefaultParityCheck : IParityMethod
             (parity == Parity.Backhand && y == note.y && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) },
         { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) ||
             (parity == Parity.Backhand && y == note.y && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) },
-        { 4, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
-        { 5, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
-        { 6, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
-        { 7, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
+        { 4, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x && x != 3 },
+        { 5, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x && x != 0 },
+        { 6, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x && x != 3 },
+        { 7, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x && x != 0 },
         { 8, (note,x,y, parity) => false }
     };
 

--- a/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
+++ b/Assets/Scripts/Core/Parity Behaviours/DefaultParityCheck.cs
@@ -18,9 +18,9 @@ public class DefaultParityCheck : IParityMethod
     {
         { 0, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x },
         { 1, (note, x, y, parity) => ((y <= note.y && y != 2) || (y < note.y && y < 2)) && x == note.x },
-        { 2, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) ||
+        { 2, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 3 && x < note.x) || (note.x < 3 && x <= note.x))) ||
             (parity == Parity.Backhand && y == note.y && ((note.x != 0 && x < note.x) || (note.x > 0 && x <= note.x))) },
-        { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) ||
+        { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.y || y == note.y - 1) && ((note.x != 0 && x > note.x) || (note.x > 0 && x >= note.x))) ||
             (parity == Parity.Backhand && y == note.y && ((note.x != 3 && x > note.x) || (note.x < 3 && x >= note.x))) },
         { 4, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x && x != 3 },
         { 5, (note, x, y, parity) => ((y >= note.y && y != 0) || (y > note.y && y > 0)) && x == note.x && x != 0 },

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -387,7 +387,6 @@ public class SliceMap
         return;
     }
 
-
     // Attempts to add bomb avoidance based on the isReset tag for a list of swings.
     // NOTE: To improve this, probably want bomb detection in its own function and these swings
     // would be added for each bomb in the sabers path rather then only for bomb resets.

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -284,24 +284,30 @@ public class SliceMap
             // Work out Parity
             List<BombNote> bombsBetweenSwings = bombs.FindAll(x => x.b > lastNote.b && x.b < notesInSwing[^1].b);
 
+            // Perform dot checks depending on swing composition.
+            if (sData.notesInCut.All(x => x.d == 8) && sData.notesInCut.Count > 1) CalculateDotStackSwingAngle(lastSwing, ref sData);
+            if (sData.notesInCut[0].d == 8 && sData.notesInCut.Count == 1) CalculateDotDirection(lastSwing, ref sData);
+
             sData.sliceParity = _parityMethodology.ParityCheck(lastSwing, ref sData, bombsBetweenSwings, _playerXOffset, _rightHand);
 
             // Depending on parity, set angle
-            if (sData.sliceParity == Parity.Backhand) {
-                sData.SetStartAngle(BackhandDict[notesInSwing[0].d]);
-                sData.SetEndAngle(BackhandDict[notesInSwing[^1].d]);
-            } else {
-                sData.SetStartAngle(ForehandDict[notesInSwing[0].d]);
-                sData.SetEndAngle(ForehandDict[notesInSwing[^1].d]);
+            if (sData.notesInCut.Any(x => x.d != 8))
+            {
+                if (sData.sliceParity == Parity.Backhand)
+                {
+                    sData.SetStartAngle(BackhandDict[notesInSwing[0].d]);
+                    sData.SetEndAngle(BackhandDict[notesInSwing[^1].d]);
+                }
+                else
+                {
+                    sData.SetStartAngle(ForehandDict[notesInSwing[0].d]);
+                    sData.SetEndAngle(ForehandDict[notesInSwing[^1].d]);
+                }
             }
 
             // If parity is the same as before and not flagged as a bomb reset.
             // LATER: Add logic to determine if adding a swing or rolling is the better option.
             if (sData.sliceParity == lastSwing.sliceParity && sData.resetType != ResetType.Bomb) { sData.resetType = ResetType.Normal; }
-
-            // Perform dot checks depending on swing composition.
-            if (sData.notesInCut.All(x => x.d == 8) && sData.notesInCut.Count > 1) CalculateDotStackSwingAngle(lastSwing, ref sData);
-            if (sData.notesInCut[0].d == 8 && sData.notesInCut.Count == 1) CalculateDotDirection(lastSwing, ref sData);
 
             // If current parity method thinks we are upside down and not dot notes in next hit, flip values.
             // This catch is in place to turn -180 into 180 (because the dictionary only has a definition from all the way around
@@ -370,8 +376,8 @@ public class SliceMap
         // stop it having a fit.
         angle = ForehandDict[orientation];
 
-        if (firstNote.x > lastSwing.notesInCut[^1].x && angle == -90 && currentSwing.sliceParity == Parity.Forehand) angle *= -1;
-        if (firstNote.x > lastSwing.notesInCut[^1].x && angle == 90 && currentSwing.sliceParity == Parity.Backhand) angle *= -1;
+        if (firstNote.x > lastSwing.notesInCut[^1].x && angle == -90 && lastSwing.sliceParity == Parity.Backhand) angle *= -1;
+        if (firstNote.x > lastSwing.notesInCut[^1].x && angle == 90 && lastSwing.sliceParity == Parity.Forehand) angle *= -1;
         if (angle == -180 || angle == 180) angle = 0;
 
         currentSwing.SetStartAngle(angle);
@@ -402,8 +408,8 @@ public class SliceMap
         if (xDiff == 3) angle = Mathf.Clamp(angle, -90, 90);
 
         // Clamps inwards backhand hits if the note is only 1 away
-        if (xDiff == 1 && lastNote.x > dotNote.x && _rightHand && currentSwing.sliceParity == Parity.Backhand) angle = 0;
-        else if (xDiff == 1 && lastNote.x < dotNote.x && !_rightHand && currentSwing.sliceParity == Parity.Backhand) angle = 0;
+        if (xDiff == 1 && lastNote.x > dotNote.x && _rightHand && lastSwing.sliceParity == Parity.Forehand) angle = 0;
+        else if (xDiff == 1 && lastNote.x < dotNote.x && !_rightHand && lastSwing.sliceParity == Parity.Forehand) angle = 0;
 
         currentSwing.SetStartAngle(angle);
         currentSwing.SetEndAngle(angle);

--- a/Assets/Scripts/Core/SliceMap.cs
+++ b/Assets/Scripts/Core/SliceMap.cs
@@ -360,10 +360,7 @@ public class SliceMap
         ColourNote firstNote = currentSwing.notesInCut[0];
         ColourNote lastNote = currentSwing.notesInCut[^1];
 
-        Vector2 dir = (new Vector2(lastNote.x, lastNote.y) - new Vector2(firstNote.x, firstNote.y)).normalized;
-        Vector2 lowestDotProduct = directionalVectors.OrderBy(v => Vector2.Dot(dir, v)).First();
-        Vector2 cutDirection = new Vector2(Mathf.Round(lowestDotProduct.x), Mathf.Round(lowestDotProduct.y));
-        int orientation = directionalVectorToCutDirection[cutDirection];
+        int orientation = CutDirFromNoteToNote(firstNote, lastNote);
 
         angle = (lastSwing.sliceParity == Parity.Backhand) ?
             ForehandDict[orientation] :
@@ -381,10 +378,7 @@ public class SliceMap
         ColourNote dotNote = currentSwing.notesInCut[0];
         ColourNote lastNote = lastSwing.notesInCut[^1];
 
-        Vector2 dir = (new Vector2(dotNote.x, dotNote.y) - new Vector2(lastNote.x, lastNote.y)).normalized;
-        Vector2 lowestDotProduct = directionalVectors.OrderBy(v => Vector2.Dot(dir, v)).First();
-        Vector2 cutDirection = new Vector2(Mathf.Round(lowestDotProduct.x), Mathf.Round(lowestDotProduct.y));
-        int orientation = directionalVectorToCutDirection[cutDirection];
+        int orientation = CutDirFromNoteToNote(lastNote, dotNote);
 
         if (dotNote.x == lastNote.x && dotNote.y == lastNote.y) {
             orientation = opposingCutDict[orientation];
@@ -465,6 +459,15 @@ public class SliceMap
     #endregion
 
     #region Helper Functions
+    // Given 2 notes, gets the cut direction of the 2nd note based on the direction from first to last
+    private int CutDirFromNoteToNote(ColourNote firstNote, ColourNote lastNote)
+    {
+        Vector2 dir = (new Vector2(lastNote.x, lastNote.y) - new Vector2(firstNote.x, firstNote.y)).normalized;
+        Vector2 lowestDotProduct = directionalVectors.OrderBy(v => Vector2.Dot(dir, v)).First();
+        Vector2 cutDirection = new Vector2(Mathf.Round(lowestDotProduct.x), Mathf.Round(lowestDotProduct.y));
+        int orientation = directionalVectorToCutDirection[cutDirection];
+        return orientation;
+    }
     // Given a cut direction ID, return angle from appropriate dictionary
     public static float AngleGivenCutDirection(int cutDirection, Parity parity)
     {

--- a/Assets/Scripts/GameObjects/BeatWallObject.cs
+++ b/Assets/Scripts/GameObjects/BeatWallObject.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class BeatWallObject : MonoBehaviour
+{
+    [SerializeField] private GameObject _wall;
+    [SerializeField] private Color _wallColour;
+    [SerializeField] private float _timeToReachTarget = 0.4f;
+
+    [SerializeField] private int _x;
+    [SerializeField] private int _y;
+    [SerializeField] private int _w;
+    [SerializeField] private int _h;
+    [SerializeField] private int _l;
+
+    private IRuntimeLevelContext _runtimeLevelContext;
+    private float _elapsedTime = 0.0f;
+
+    public void Init(int x, int y, int w, int h, int l, float moveSpeed, IRuntimeLevelContext runtimeLevelContext)
+    {
+        _runtimeLevelContext = runtimeLevelContext;
+        _timeToReachTarget = 4.0f / moveSpeed;
+        _x = x;
+        _y = y;
+        _w = w;
+        _h = h;
+        _l = l;
+
+        float xOffsetting = (w % 2 == 1) ? 1 : 0.4f;
+
+        transform.position = LevelUtils.GetWorldXYFromBeatmapCoords(x - (w/2), 2-(y + (h/2)));
+        if (w > 1) transform.position = new(transform.position.x + w - xOffsetting, transform.position.y);
+        transform.localScale = new Vector3(_w, Mathf.Clamp(_h,2,3), 1);
+    }
+}

--- a/Assets/Scripts/GameObjects/BeatWallObject.cs.meta
+++ b/Assets/Scripts/GameObjects/BeatWallObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7b0d3777ccaf4644b4c810ac0115229
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Bomb Logic Improved further, can now play shappy bombs on fly wit me. Added a second bomb check that determines if resetting would cause more problems then it solves
- Modified and functionalised dot direction deciding logic
- Full dots or Full arrow swings are now correctly sorted in order of being hit using vectors and dot product (Need to implement this for dot and arrow swings)
- Wall Object Implementation, they will now appear in the previewer (Need to implement a way for the length to be calculated)